### PR TITLE
etnaviv: handle drm: deprecate driver date since kernel 6.11

### DIFF
--- a/etnaviv/etnadrm.c
+++ b/etnaviv/etnadrm.c
@@ -191,6 +191,14 @@ int viv_open(enum viv_hw_type hw_type, struct viv_conn **out)
 	 */
 	ec->api_date = atoi(version->date);
 
+	/*
+	 * Since kernel 6.11, the date returned by the drm is always 0.
+	 * Use a default value instead, which can be overriden. It means that
+	 * this date has to be aligned with the kernel etnaviv drm date...
+	 */
+	if (!ec->api_date)
+		ec->api_date = DEFAULT_ETNAVIV_DATE;
+
 	conn->base_address = 0;
 
 	/*

--- a/etnaviv/etnaviv_drm.h
+++ b/etnaviv/etnaviv_drm.h
@@ -25,6 +25,11 @@
 #define ETNAVIV_DATE_PENGUTRONIX4	20151214
 #define ETNAVIV_DATE			ETNAVIV_DATE_PENGUTRONIX
 
+// By default use the latest
+#ifndef DEFAULT_ETNAVIV_DATE
+#define DEFAULT_ETNAVIV_DATE  ETNAVIV_DATE_PENGUTRONIX4
+#endif
+
 #include <stddef.h>
 #include "drm.h"
 


### PR DESCRIPTION
Since kernel 6.11, driver date is no longer updated and always returns 0. Under the hood, DRM_IOCTL_VERSION is called. Thus the api used is the original one.

Using the latest version as a fix if the version->date returned equals 0. The version can be overriden by defining DEFAULT_ETNAVIV_DATE beforehand.

Commits which introduced the change in kernel 6.11:
 * 7fb8af6798e8d013017e4607505f58d9942fd671 : drm: deprecate driver date
 * 11cdc8f2bde4bc548da6f995556c4b7183431088 : drm: use "0" instead of "" for deprecated driver date